### PR TITLE
Exposing headers on NetworkRequest

### DIFF
--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -53,6 +53,7 @@ public extension NetworkRequest {
         }
         
         urlRequest.httpMethod = httpMethod.rawValue
+        httpHeaders.forEach { urlRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
         urlRequest.httpBody = httpBody
         
         return urlRequest


### PR DESCRIPTION
## What it Does

- Exposes the ability to provide http headers on a network request.

- This is intended to allow you to add common headers for a request that may not be ideal to use as a `RequestBehavior`. Example being having to set the boundary of a multipart form data request.

## How I Tested

- I ran the app and made sure it built.
