### PR TITLE
Makes `JSONDecoder` Injectable

### DIFF
--- a/Sources/Networking/NetworkRequestPerformer+JSON.swift
+++ b/Sources/Networking/NetworkRequestPerformer+JSON.swift
@@ -15,14 +15,13 @@ extension NetworkRequestPerformer {
     /// - Parameters:
     ///   - request: The request to perform.
     ///   - requestBehaviors: The behaviors to apply to the given request.
+    ///   - decoder: The JSON decoder to use when decoding the data.
     ///   - completion: A completion closure that is called when the request has been completed.
     /// - Returns: The `URLSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
-    @discardableResult public func send<ResponseType: Decodable>(_ request: NetworkRequest, requestBehaviors: [RequestBehavior] = [], completion: ((Result<ResponseType, NetworkError>) -> Void)? = nil) -> URLSessionDataTask {
+    @discardableResult public func send<ResponseType: Decodable>(_ request: NetworkRequest, requestBehaviors: [RequestBehavior] = [], decoder: JSONDecoder = JSONDecoder(), completion: ((Result<ResponseType, NetworkError>) -> Void)? = nil) -> URLSessionDataTask {
         send(request, requestBehaviors: requestBehaviors) { result in
             switch result {
             case let .success(response):
-         
-                let decoder = JSONDecoder()
                 if let data = response.data {
                     do {
                         let decodedInstance = try decoder.decode(ResponseType.self, from: data)


### PR DESCRIPTION
## What it Does

Currently, there is no way to customize the `JSONDecoder` used in the convenience `send` request and parsing function. I made it injectable as an argument to the function call with a default value, so that this change won't affect current callers but allows clients to inject their own decoders now.

## How I Tested

Built the app successfully.