### PR TITLE
Mock URLSession Behavior for Testing

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -11,7 +11,7 @@ import Combine
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    let controller = NetworkController(urlSession: .shared)
+    let controller = NetworkController()
     var cancellables = Set<AnyCancellable>()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B96DC552A0AB67B00FF0499 /* NetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */; };
+		0B96DC572A0AB91B00FF0499 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */; };
 		4C2CBFAC24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */; };
 		F211601924884A4D00B48D52 /* PhotoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601824884A4D00B48D52 /* PhotoRequest.swift */; };
 		F211601B24884ABF00B48D52 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601A24884ABF00B48D52 /* Photo.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSession.swift; sourceTree = "<group>"; };
+		0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
 		4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkRequestPerformer+JSON.swift"; sourceTree = "<group>"; };
 		F211601824884A4D00B48D52 /* PhotoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRequest.swift; sourceTree = "<group>"; };
 		F211601A24884ABF00B48D52 /* Photo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
@@ -103,6 +107,7 @@
 				F2B5BC522488378200B6A52A /* RequestBehavior.swift */,
 				F2B5BC54248837B400B6A52A /* NetworkRequestPerformer.swift */,
 				F2B5BC56248837CB00B6A52A /* NetworkController.swift */,
+				0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */,
 				4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */,
 				F264BB4D28BE9D6500969CD1 /* NetworkRequestStateController.swift */,
 				F264BB4F28BE9E1700969CD1 /* Publisher+Result.swift */,
@@ -149,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				F2B5BC3D248836C600B6A52A /* NetworkingTests.swift */,
+				0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */,
 				F2B5BC3F248836C600B6A52A /* Info.plist */,
 			);
 			path = Tests;
@@ -293,6 +299,7 @@
 				F264BB5028BE9E1700969CD1 /* Publisher+Result.swift in Sources */,
 				F2B5BC2B248836C500B6A52A /* ContentView.swift in Sources */,
 				4C2CBFAC24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift in Sources */,
+				0B96DC552A0AB67B00FF0499 /* NetworkSession.swift in Sources */,
 				F2B5BC4F2488376C00B6A52A /* NetworkRequest.swift in Sources */,
 				F2B5BC4D2488375C00B6A52A /* NetworkError.swift in Sources */,
 			);
@@ -303,6 +310,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F2B5BC3E248836C600B6A52A /* NetworkingTests.swift in Sources */,
+				0B96DC572A0AB91B00FF0499 /* MockNetworkSession.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0B96DC552A0AB67B00FF0499 /* NetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */; };
 		0B96DC572A0AB91B00FF0499 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */; };
+		0B96DC5A2A0AC7E800FF0499 /* NetworkSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC582A0AC7A800FF0499 /* NetworkSessionDataTask.swift */; };
 		4C2CBFAC24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */; };
 		F211601924884A4D00B48D52 /* PhotoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601824884A4D00B48D52 /* PhotoRequest.swift */; };
 		F211601B24884ABF00B48D52 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601A24884ABF00B48D52 /* Photo.swift */; };
@@ -44,6 +45,7 @@
 /* Begin PBXFileReference section */
 		0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSession.swift; sourceTree = "<group>"; };
 		0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
+		0B96DC582A0AC7A800FF0499 /* NetworkSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionDataTask.swift; sourceTree = "<group>"; };
 		4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkRequestPerformer+JSON.swift"; sourceTree = "<group>"; };
 		F211601824884A4D00B48D52 /* PhotoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRequest.swift; sourceTree = "<group>"; };
 		F211601A24884ABF00B48D52 /* Photo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				F2B5BC54248837B400B6A52A /* NetworkRequestPerformer.swift */,
 				F2B5BC56248837CB00B6A52A /* NetworkController.swift */,
 				0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */,
+				0B96DC582A0AC7A800FF0499 /* NetworkSessionDataTask.swift */,
 				4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */,
 				F264BB4D28BE9D6500969CD1 /* NetworkRequestStateController.swift */,
 				F264BB4F28BE9E1700969CD1 /* Publisher+Result.swift */,
@@ -289,6 +292,7 @@
 				F211601B24884ABF00B48D52 /* Photo.swift in Sources */,
 				F2B5BC57248837CB00B6A52A /* NetworkController.swift in Sources */,
 				F2B5BC49248836F300B6A52A /* HTTPMethod.swift in Sources */,
+				0B96DC5A2A0AC7E800FF0499 /* NetworkSessionDataTask.swift in Sources */,
 				F2B5BC532488378200B6A52A /* RequestBehavior.swift in Sources */,
 				F2B5BC55248837B400B6A52A /* NetworkRequestPerformer.swift in Sources */,
 				F2B5BC27248836C500B6A52A /* AppDelegate.swift in Sources */,

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0B96DC552A0AB67B00FF0499 /* NetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */; };
 		0B96DC572A0AB91B00FF0499 /* MockNetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */; };
 		0B96DC5A2A0AC7E800FF0499 /* NetworkSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC582A0AC7A800FF0499 /* NetworkSessionDataTask.swift */; };
+		0B96DC5C2A0AC99F00FF0499 /* NetworkControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B96DC5B2A0AC99F00FF0499 /* NetworkControllerTests.swift */; };
 		4C2CBFAC24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */; };
 		F211601924884A4D00B48D52 /* PhotoRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601824884A4D00B48D52 /* PhotoRequest.swift */; };
 		F211601B24884ABF00B48D52 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F211601A24884ABF00B48D52 /* Photo.swift */; };
@@ -46,6 +47,7 @@
 		0B96DC542A0AB67B00FF0499 /* NetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSession.swift; sourceTree = "<group>"; };
 		0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkSession.swift; sourceTree = "<group>"; };
 		0B96DC582A0AC7A800FF0499 /* NetworkSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSessionDataTask.swift; sourceTree = "<group>"; };
+		0B96DC5B2A0AC99F00FF0499 /* NetworkControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkControllerTests.swift; sourceTree = "<group>"; };
 		4C2CBFAB24D4AA9800920BE2 /* NetworkRequestPerformer+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkRequestPerformer+JSON.swift"; sourceTree = "<group>"; };
 		F211601824884A4D00B48D52 /* PhotoRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoRequest.swift; sourceTree = "<group>"; };
 		F211601A24884ABF00B48D52 /* Photo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 			children = (
 				F2B5BC3D248836C600B6A52A /* NetworkingTests.swift */,
 				0B96DC562A0AB91B00FF0499 /* MockNetworkSession.swift */,
+				0B96DC5B2A0AC99F00FF0499 /* NetworkControllerTests.swift */,
 				F2B5BC3F248836C600B6A52A /* Info.plist */,
 			);
 			path = Tests;
@@ -314,6 +317,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F2B5BC3E248836C600B6A52A /* NetworkingTests.swift in Sources */,
+				0B96DC5C2A0AC99F00FF0499 /* NetworkControllerTests.swift in Sources */,
 				0B96DC572A0AB91B00FF0499 /* MockNetworkSession.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Networking/NetworkController.swift
+++ b/Sources/Networking/NetworkController.swift
@@ -33,9 +33,9 @@ public final class NetworkController {
         return urlRequest
     }
 
-    private func makeDataTask(forURLRequest urlRequest: URLRequest, behaviors: [RequestBehavior] = [], successHTTPStatusCodes: HTTPStatusCodes, completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> URLSessionDataTask {
+    private func makeDataTask(forURLRequest urlRequest: URLRequest, behaviors: [RequestBehavior] = [], successHTTPStatusCodes: HTTPStatusCodes, completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask {
 
-        return networkSession.dataTask(with: urlRequest) { data, response, error in
+        return networkSession.makeDataTask(with: urlRequest) { data, response, error in
             let result: Result<NetworkResponse, NetworkError>
             
             if let error = error {
@@ -61,7 +61,7 @@ extension NetworkController: NetworkRequestPerformer {
     
     // MARK: - NetworkRequestPerformer
     
-    @discardableResult public func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], completion: ((Result<NetworkResponse, NetworkError>) -> Void)? = nil) -> URLSessionDataTask {
+    @discardableResult public func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], completion: ((Result<NetworkResponse, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
         let behaviors = defaultRequestBehaviors + requestBehaviors
 
         let urlRequest = makeFinalizedRequest(fromOriginalRequest: request.urlRequest, behaviors: behaviors)

--- a/Sources/Networking/NetworkController.swift
+++ b/Sources/Networking/NetworkController.swift
@@ -65,7 +65,7 @@ extension NetworkController: NetworkRequestPerformer {
         let behaviors = defaultRequestBehaviors + requestBehaviors
 
         let urlRequest = makeFinalizedRequest(fromOriginalRequest: request.urlRequest, behaviors: behaviors)
-        let dataTask = makeDataTask(forURLRequest: urlRequest, successHTTPStatusCodes: request.successHTTPStatusCodes, completion: completion)
+        let dataTask = makeDataTask(forURLRequest: urlRequest, behaviors: behaviors, successHTTPStatusCodes: request.successHTTPStatusCodes, completion: completion)
 
         dataTask.resume()
 

--- a/Sources/Networking/NetworkRequestPerformer+JSON.swift
+++ b/Sources/Networking/NetworkRequestPerformer+JSON.swift
@@ -17,8 +17,8 @@ extension NetworkRequestPerformer {
     ///   - requestBehaviors: The behaviors to apply to the given request.
     ///   - decoder: The JSON decoder to use when decoding the data.
     ///   - completion: A completion closure that is called when the request has been completed.
-    /// - Returns: The `URLSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
-    @discardableResult public func send<ResponseType: Decodable>(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], decoder: JSONDecoder = JSONDecoder(), completion: ((Result<ResponseType, NetworkError>) -> Void)? = nil) -> URLSessionDataTask {
+    /// - Returns: The `NetworkSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
+    @discardableResult public func send<ResponseType: Decodable>(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], decoder: JSONDecoder = JSONDecoder(), completion: ((Result<ResponseType, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
         send(request, requestBehaviors: requestBehaviors) { result in
             switch result {
             case let .success(response):

--- a/Sources/Networking/NetworkRequestPerformer.swift
+++ b/Sources/Networking/NetworkRequestPerformer.swift
@@ -18,8 +18,8 @@ public protocol NetworkRequestPerformer {
     ///   - request: The request to perform.
     ///   - requestBehaviors: The behaviors to apply to the given request.
     ///   - completion: A completion closure that is called when the request has been completed.
-    /// - Returns: The `URLSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
-    @discardableResult func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior], completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> URLSessionDataTask
+    /// - Returns: The `NetworkSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
+    @discardableResult func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior], completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask
 
     /// Returns a publisher that can be subscribed to, that performs the given request with the given behaviors.
     /// - Parameters:

--- a/Sources/Networking/NetworkSession.swift
+++ b/Sources/Networking/NetworkSession.swift
@@ -19,7 +19,7 @@ public protocol NetworkSession {
     /// - Returns: The new session data task.
     ///
     /// - Note: This documentation is pulled directly from `URLSession`.
-    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+    func makeDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask
 
     /// Returns a publisher that wraps a URL session data task for a given URL request.
     ///
@@ -31,4 +31,14 @@ public protocol NetworkSession {
     func dataTaskPublisher(for request: URLRequest) -> URLSession.DataTaskPublisher
 }
 
-extension URLSession: NetworkSession { }
+extension URLSession: NetworkSession {
+    public func makeDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask {
+        return dataTask(with: request, completionHandler: completionHandler)
+    }
+}
+
+public protocol NetworkSessionDataTask {
+    func resume()
+}
+
+extension URLSessionDataTask: NetworkSessionDataTask { }

--- a/Sources/Networking/NetworkSession.swift
+++ b/Sources/Networking/NetworkSession.swift
@@ -32,13 +32,10 @@ public protocol NetworkSession {
 }
 
 extension URLSession: NetworkSession {
+
+    // MARK: - NetworkSession
+
     public func makeDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask {
         return dataTask(with: request, completionHandler: completionHandler)
     }
 }
-
-public protocol NetworkSessionDataTask {
-    func resume()
-}
-
-extension URLSessionDataTask: NetworkSessionDataTask { }

--- a/Sources/Networking/NetworkSession.swift
+++ b/Sources/Networking/NetworkSession.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkSession.swift
+//  Networking
+//
+//  Created by Michael Liberatore on 5/9/23.
+//  Copyright © 2023 Lickability. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+/// Describes an object that coordinates a group of related, network data transfer tasks. This protocol has a similar API to `URLSession` for the purpose of mocking.
+public protocol NetworkSession {
+
+    /// Creates a task that retrieves the contents of a URL based on the specified URL request object, and calls a handler upon completion.
+    /// - Parameters:
+    ///   - request: A URL request object that provides the URL, cache policy, request type, body data or body stream, and so on.
+    ///   - completionHandler: The completion handler to call when the load request is complete. This handler is executed on the delegate queue.
+    /// - Returns: The new session data task.
+    ///
+    /// - Note: This documentation is pulled directly from `URLSession`.
+    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+
+    /// Returns a publisher that wraps a URL session data task for a given URL request.
+    ///
+    /// The publisher publishes data when the task completes, or terminates if the task fails with an error.
+    /// - Parameter request: The URL request for which to create a data task.
+    /// - Returns: A publisher that wraps a data task for the URL request.
+    ///
+    /// - Note: This documentation is pulled directly from `URLSession`.
+    func dataTaskPublisher(for request: URLRequest) -> URLSession.DataTaskPublisher
+}
+
+extension URLSession: NetworkSession { }

--- a/Sources/Networking/NetworkSessionDataTask.swift
+++ b/Sources/Networking/NetworkSessionDataTask.swift
@@ -1,0 +1,20 @@
+//
+//  NetworkSessionDataTask.swift
+//  NetworkingTests
+//
+//  Created by Michael Liberatore on 5/9/23.
+//  Copyright © 2023 Lickability. All rights reserved.
+//
+
+import Foundation
+
+/// Describes a network session task that can be performed. This protocol has a similar API to `URLSessionDataTask` for the purpose of mocking.
+public protocol NetworkSessionDataTask {
+
+    /// Resumes the task, if it is suspended.
+    ///
+    /// - Note: This documentation is pulled directly from `URLSessionTask`.
+    func resume()
+}
+
+extension URLSessionDataTask: NetworkSessionDataTask { }

--- a/Tests/MockNetworkSession.swift
+++ b/Tests/MockNetworkSession.swift
@@ -1,0 +1,49 @@
+//
+//  MockNetworkSession.swift
+//  NetworkingTests
+//
+//  Created by Michael Liberatore on 5/9/23.
+//  Copyright © 2023 Lickability. All rights reserved.
+//
+
+import Foundation
+import Networking
+
+class MockNetworkSession: NetworkSession {
+
+    private let result: Result<Data, Error>
+    init(result: Result<Data, Error>) {
+        self.result = result
+    }
+
+    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        return MockSessionDataTask { [weak self] in
+            switch self?.result {
+            case .success(let data):
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+                completionHandler(data, response, nil)
+            case .failure(let error):
+                let response = HTTPURLResponse(url: request.url!, statusCode: 0, httpVersion: nil, headerFields: nil)
+                completionHandler(nil, response, error)
+            case .none:
+                assertionFailure("`MockNetworkSession` went out of scope. Keep a reference to it for the duration of your tests.")
+            }
+        }
+    }
+
+    func dataTaskPublisher(for request: URLRequest) -> URLSession.DataTaskPublisher {
+        return URLSession.DataTaskPublisher(request: request, session: .shared) // not currently mocked.
+    }
+}
+
+private class MockSessionDataTask: URLSessionDataTask {
+    private let closure: () -> Void
+
+    init(closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+
+    override func resume() {
+        closure()
+    }
+}

--- a/Tests/MockNetworkSession.swift
+++ b/Tests/MockNetworkSession.swift
@@ -9,15 +9,20 @@
 import Foundation
 import Networking
 
+/// A mocked version of `NetworkSession` to be used in tests. Allows specification of specific success or failure cases.
 class MockNetworkSession: NetworkSession {
-
     private let result: Result<Data, Error>
+
+    /// Creates a new `MockNetworkSession`.
+    /// - Parameter result: The expected result of network requests performed by this mock.
     init(result: Result<Data, Error>) {
         self.result = result
     }
 
-    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        return MockSessionDataTask { [weak self] in
+    // MARK: - NetworkSession
+
+    func makeDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask {
+        return MockNetworkSessionDataTask { [weak self] in
             switch self?.result {
             case .success(let data):
                 let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
@@ -36,14 +41,14 @@ class MockNetworkSession: NetworkSession {
     }
 }
 
-private class MockSessionDataTask: URLSessionDataTask {
-    private let closure: () -> Void
+private class MockNetworkSessionDataTask: NetworkSessionDataTask {
+    private let resumeClosure: () -> Void
 
     init(closure: @escaping () -> Void) {
-        self.closure = closure
+        self.resumeClosure = closure
     }
 
-    override func resume() {
-        closure()
+    func resume() {
+        resumeClosure()
     }
 }

--- a/Tests/MockNetworkSession.swift
+++ b/Tests/MockNetworkSession.swift
@@ -25,10 +25,10 @@ class MockNetworkSession: NetworkSession {
         return MockNetworkSessionDataTask { [weak self] in
             switch self?.result {
             case .success(let data):
-                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+                let response = request.url.flatMap { HTTPURLResponse(url: $0, statusCode: 200, httpVersion: nil, headerFields: nil) }
                 completionHandler(data, response, nil)
             case .failure(let error):
-                let response = HTTPURLResponse(url: request.url!, statusCode: 0, httpVersion: nil, headerFields: nil)
+                let response = request.url.flatMap { HTTPURLResponse(url: $0, statusCode: 0, httpVersion: nil, headerFields: nil) }
                 completionHandler(nil, response, error)
             case .none:
                 assertionFailure("`MockNetworkSession` went out of scope. Keep a reference to it for the duration of your tests.")

--- a/Tests/NetworkControllerTests.swift
+++ b/Tests/NetworkControllerTests.swift
@@ -1,0 +1,97 @@
+//
+//  NetworkControllerTests.swift
+//  NetworkingTests
+//
+//  Created by Michael Liberatore on 5/9/23.
+//  Copyright © 2023 Lickability. All rights reserved.
+//
+
+import XCTest
+@testable import Networking
+
+class NetworkControllerTests: XCTestCase {
+
+    func testAsyncAwaitSendWithFailure() async throws {
+        let networkController = NetworkController(networkSession: MockNetworkSession(result: .failure(NetworkError.noResponse)))
+
+        do {
+            let _: [Photo] = try await networkController.send(PhotoRequest.photosList, requestBehaviors: [])
+            XCTFail("Should’ve caught an error before reaching here.")
+        }
+        catch {
+            guard let networkError = error as? NetworkError else {
+                XCTFail("Encountered an unexpected error type")
+                return
+            }
+
+            switch networkError {
+            case .decodingError, .noData, .noResponse, .unsuccessfulStatusCode:
+                XCTFail("Encountered an unexpected NetworkError type")
+            case .underlyingNetworkingError(let underlyingError):
+                guard let underlyingNetworkError = underlyingError as? NetworkError else {
+                    XCTFail("Encountered an unexpected underlying error type")
+                    return
+                }
+
+                XCTAssertEqual(underlyingNetworkError.failureReason, NetworkError.noResponse.failureReason)
+            }
+        }
+    }
+
+    func testAsyncAwaitSendWithSuccess() async throws {
+        let photos: [Photo] = [
+            Photo(albumId: 1, id: 1, title: "1", url: "", thumbnailUrl: ""),
+            Photo(albumId: 1, id: 2, title: "1", url: "", thumbnailUrl: ""),
+            Photo(albumId: 1, id: 3, title: "1", url: "", thumbnailUrl: "")
+        ]
+
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(photos)
+            let networkController = NetworkController(networkSession: MockNetworkSession(result: .success(data)))
+            let photosResponse: NetworkResponse = try await networkController.send(PhotoRequest.photosList, requestBehaviors: [])
+            let decodedData = photosResponse.data
+
+            XCTAssertEqual(data, decodedData)
+        }
+        catch {
+            XCTFail("Unexpected error occurred: \(error).")
+        }
+    }
+
+    func testAsyncAwaitBehaviors() async throws {
+        let networkController = NetworkController(networkSession: MockNetworkSession(result: .failure(NetworkError.noResponse)))
+
+        var requestWillSendWasCalled = false
+        var requestDidFinishWasCalled = false
+
+        let behavior = TestBehavior {
+            requestWillSendWasCalled = true
+            XCTAssertFalse(requestDidFinishWasCalled, "We should’ve reached this point before `requestDidFinishWasCalled` became true.")
+        } didFinishClosure: {
+            requestDidFinishWasCalled = true
+        }
+
+        do {
+            let _: [Photo] = try await networkController.send(PhotoRequest.photosList, requestBehaviors: [behavior])
+            XCTFail("Should’ve caught an error before reaching here.")
+        }
+        catch {
+            XCTAssertTrue(requestWillSendWasCalled)
+            XCTAssertTrue(requestDidFinishWasCalled)
+        }
+    }
+}
+
+private struct TestBehavior: RequestBehavior {
+    let willSendClosure: () -> Void
+    let didFinishClosure: () -> Void
+
+    func requestWillSend(request: inout URLRequest) {
+        willSendClosure()
+    }
+
+    func requestDidFinish(result: Result<NetworkResponse, NetworkError>) {
+        didFinishClosure()
+    }
+}

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -11,9 +11,36 @@ import XCTest
 
 class NetworkingTests: XCTestCase {
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testExample() async throws {
+        let networkController1 = NetworkController(networkSession: MockNetworkSession(result: .failure(NetworkError.noResponse)))
+
+        do {
+            let _: [Photo] = try await networkController1.send(PhotoRequest.photosList, requestBehaviors: [])
+            XCTFail("Should’ve caught an error here.")
+        }
+        catch {
+            print("error: \(error)")
+        }
+
+        let photos: [Photo] = [
+            Photo(albumId: 1, id: 1, title: "1", url: "", thumbnailUrl: ""),
+            Photo(albumId: 1, id: 2, title: "1", url: "", thumbnailUrl: ""),
+            Photo(albumId: 1, id: 3, title: "1", url: "", thumbnailUrl: "")
+        ]
+
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(photos)
+            let networkController2 = NetworkController(networkSession: MockNetworkSession(result: .success(data)))
+            let photosResponse: NetworkResponse = try await networkController2.send(PhotoRequest.photosList, requestBehaviors: [])
+            let decodedData = photosResponse.data
+
+            XCTAssertEqual(data, decodedData)
+            //XCTAssertEqual(photos.map { $0.id }, [1, 2, 3])
+        }
+        catch {
+            XCTFail("Unexpected error occurred: \(error).")
+        }
     }
 
     func testPerformanceExample() throws {

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -11,36 +11,9 @@ import XCTest
 
 class NetworkingTests: XCTestCase {
 
-    func testExample() async throws {
-        let networkController1 = NetworkController(networkSession: MockNetworkSession(result: .failure(NetworkError.noResponse)))
-
-        do {
-            let _: [Photo] = try await networkController1.send(PhotoRequest.photosList, requestBehaviors: [])
-            XCTFail("Should’ve caught an error here.")
-        }
-        catch {
-            print("error: \(error)")
-        }
-
-        let photos: [Photo] = [
-            Photo(albumId: 1, id: 1, title: "1", url: "", thumbnailUrl: ""),
-            Photo(albumId: 1, id: 2, title: "1", url: "", thumbnailUrl: ""),
-            Photo(albumId: 1, id: 3, title: "1", url: "", thumbnailUrl: "")
-        ]
-
-        let encoder = JSONEncoder()
-        do {
-            let data = try encoder.encode(photos)
-            let networkController2 = NetworkController(networkSession: MockNetworkSession(result: .success(data)))
-            let photosResponse: NetworkResponse = try await networkController2.send(PhotoRequest.photosList, requestBehaviors: [])
-            let decodedData = photosResponse.data
-
-            XCTAssertEqual(data, decodedData)
-            //XCTAssertEqual(photos.map { $0.id }, [1, 2, 3])
-        }
-        catch {
-            XCTFail("Unexpected error occurred: \(error).")
-        }
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
     func testPerformanceExample() throws {


### PR DESCRIPTION
## What it Does
Follow-up to #6 

In #6 it was proposed that we’d test out the functionality, but timing-wise it didn’t make sense, so we’ve added some basic tests today.

And good news, the tests caught two bugs!

We decided to minimally mock `URLSession` and `URLSessionDataTask` with protocol conformances. This unfortunately changes some types in public APIs, but hopefully that's deemed worth it for the future of test writing in these libraries.

Additionally, strictly for time constraints, we only mocked the non-`Combine` `URLSession` method as we only intended to test the new async/await public API during this working session.

## How I Tested

1. Ran the new tests.

## Notes

See GitHub comments in the code below on the bug fixes caught by tests.

## Screenshot

N/A