### PR TITLE
NetworkRequestStateController explicit scheduler.

### DIFF
--- a/Sources/Networking/NetworkRequestStateController.swift
+++ b/Sources/Networking/NetworkRequestStateController.swift
@@ -93,10 +93,10 @@ public final class NetworkRequestStateController {
     /// Sends a request with the specified parameters.
     /// - Parameters:
     ///   - request: The request to send.
+    ///   - scheduler: The scheduler to receive the call on. The default value is `DispatchQueue.main`.
     ///   - requestBehaviors: Additional behaviors to append to the request.
     ///   - retryCount: The number of times the action can be retried.
-    ///   - scheduler: The scheduler to receive the call on. The default value is `DispatchQueue.main`.
-    public func send(request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], retryCount: Int = 2, scheduler: some Scheduler = DispatchQueue.main) {
+    public func send(request: any NetworkRequest, scheduler: some Scheduler = DispatchQueue.main, requestBehaviors: [RequestBehavior] = [], retryCount: Int = 2) {
         requestStatePublisher.send(.inProgress)
         
         requestPerformer.send(request, requestBehaviors: requestBehaviors)

--- a/Sources/Networking/NetworkRequestStateController.swift
+++ b/Sources/Networking/NetworkRequestStateController.swift
@@ -94,13 +94,15 @@ public final class NetworkRequestStateController {
     /// - Parameters:
     ///   - request: The request to send.
     ///   - requestBehaviors: Additional behaviors to append to the request.
-    public func send(request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], retryCount: Int = 2) {
+    ///   - retryCount: The number of times the action can be retried.
+    ///   - scheduler: The scheduler to receive the call on. The default value is `DispatchQueue.main`.
+    public func send(request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], retryCount: Int = 2, scheduler: some Scheduler = DispatchQueue.main) {
         requestStatePublisher.send(.inProgress)
         
         requestPerformer.send(request, requestBehaviors: requestBehaviors)
             .retry(retryCount)
             .mapAsResult()
-            .receive(on: DispatchQueue.main)
+            .receive(on: scheduler)
             .sink(receiveValue: { [requestStatePublisher] result in
                 requestStatePublisher.send(.completed(result))
             })


### PR DESCRIPTION
Closes #14

## What it Does
Allows user to explicitly set the scheduler on controller.
## How I Tested
- Launched the tests make sure the passed.
## Notes
- I added a default value to the scheduler method property, because other properties have one.
## Screenshot
