### PR TITLE
Added a progress property to the NetworkSessionDataTask

### DIFF
--- a/Sources/Networking/NetworkSessionDataTask.swift
+++ b/Sources/Networking/NetworkSessionDataTask.swift
@@ -10,7 +10,12 @@ import Foundation
 
 /// Describes a network session task that can be performed. This protocol has a similar API to `URLSessionDataTask` for the purpose of mocking.
 public protocol NetworkSessionDataTask {
-
+    
+    /// Progress object which represents the task progress. It can be used for task progress tracking.
+    ///
+    /// - Note: This documentation is pulled directly from `URLSessionTask`.
+    var progress: Progress { get }
+    
     /// Resumes the task, if it is suspended.
     ///
     /// - Note: This documentation is pulled directly from `URLSessionTask`.


### PR DESCRIPTION
Closes #16 

## What it Does
- Exposes the progress property on the network session.
## How I Tested
- Made sure the tests passes
## Notes
There is a use case where we need to see the progress of the request being sent. This will allow us to implement a progress bar.
