### PR TITLE
Swift 6 and concurrency update

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import Combine
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let controller = NetworkController()

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -234,8 +234,9 @@
 		F2B5BC1B248836C500B6A52A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1150;
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = Lickability;
 				TargetAttributes = {
 					F2B5BC22248836C500B6A52A = {
@@ -370,6 +371,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -380,6 +382,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -432,6 +435,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -442,6 +446,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -471,7 +476,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -492,7 +497,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -507,12 +512,11 @@
 		F2B5BC46248836C600B6A52A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -529,12 +533,11 @@
 		F2B5BC47248836C600B6A52A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -471,7 +471,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -492,7 +492,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -512,7 +512,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -534,7 +534,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -401,6 +401,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -454,6 +456,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -474,7 +478,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.Networking;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -495,7 +499,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.Networking;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -516,7 +520,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.NetworkingTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Networking.app/Networking";
 			};
@@ -538,7 +542,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.NetworkingTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Networking.app/Networking";
 			};

--- a/Networking.xcodeproj/project.pbxproj
+++ b/Networking.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -497,7 +497,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -516,7 +516,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -537,7 +537,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Networking.xcodeproj/xcshareddata/xcschemes/Networking.xcscheme
+++ b/Networking.xcodeproj/xcshareddata/xcschemes/Networking.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Networking/HTTPMethod.swift
+++ b/Sources/Networking/HTTPMethod.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Encapsulates HTTP methods for requests.
-public enum HTTPMethod: String {
+public enum HTTPMethod: String, Sendable {
     
     /// HTTP `GET`.
     case get = "GET"

--- a/Sources/Networking/NetworkController.swift
+++ b/Sources/Networking/NetworkController.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 /// A default concrete implementation of the `NetworkRequestPerformer`.
-public final class NetworkController {
+public final class NetworkController: Sendable {
 
     private let networkSession: NetworkSession
     private let defaultRequestBehaviors: [RequestBehavior]
@@ -33,7 +33,7 @@ public final class NetworkController {
         return urlRequest
     }
 
-    private func makeDataTask(forURLRequest urlRequest: URLRequest, behaviors: [RequestBehavior] = [], successHTTPStatusCodes: HTTPStatusCodes, completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask {
+    private func makeDataTask(forURLRequest urlRequest: URLRequest, behaviors: [RequestBehavior] = [], successHTTPStatusCodes: HTTPStatusCodes, completion: (@Sendable (Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask {
 
         return networkSession.makeDataTask(with: urlRequest) { data, response, error in
             let result: Result<NetworkResponse, NetworkError>
@@ -61,7 +61,7 @@ extension NetworkController: NetworkRequestPerformer {
     
     // MARK: - NetworkRequestPerformer
     
-    @discardableResult public func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], completion: ((Result<NetworkResponse, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
+    @discardableResult public func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], completion: (@Sendable (Result<NetworkResponse, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
         let behaviors = defaultRequestBehaviors + requestBehaviors
 
         let urlRequest = makeFinalizedRequest(fromOriginalRequest: request.urlRequest, behaviors: behaviors)

--- a/Sources/Networking/NetworkError.swift
+++ b/Sources/Networking/NetworkError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Possible errors encountered during networking.
-public enum NetworkError: LocalizedError {
+public enum NetworkError: LocalizedError, Sendable {
     
     // MARK: - NetworkError
     

--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -37,7 +37,7 @@ public protocol NetworkRequest: Equatable, Sendable {
 }
 
 /// Represents a collection of possible HTTP status codes.
-public enum HTTPStatusCodes: Equatable {
+public enum HTTPStatusCodes: Equatable, Sendable {
     
     /// All status codes.
     case all

--- a/Sources/Networking/NetworkRequest.swift
+++ b/Sources/Networking/NetworkRequest.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A protocol that defines the parameters that make up a request.
-public protocol NetworkRequest: Equatable {
+public protocol NetworkRequest: Equatable, Sendable {
     
     /// The generated `URLRequest` to use for making network requests. Defaults to a url request built using the receiver’s properties.
     var urlRequest: URLRequest { get }

--- a/Sources/Networking/NetworkRequestPerformer+JSON.swift
+++ b/Sources/Networking/NetworkRequestPerformer+JSON.swift
@@ -18,7 +18,7 @@ extension NetworkRequestPerformer {
     ///   - decoder: The JSON decoder to use when decoding the data.
     ///   - completion: A completion closure that is called when the request has been completed.
     /// - Returns: The `NetworkSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
-    @discardableResult public func send<ResponseType: Decodable>(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], decoder: JSONDecoder = JSONDecoder(), completion: ((Result<ResponseType, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
+    @discardableResult public func send<ResponseType: Decodable>(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior] = [], decoder: JSONDecoder = JSONDecoder(), completion: (@Sendable (Result<ResponseType, NetworkError>) -> Void)? = nil) -> NetworkSessionDataTask {
         send(request, requestBehaviors: requestBehaviors) { result in
             switch result {
             case let .success(response):

--- a/Sources/Networking/NetworkRequestPerformer.swift
+++ b/Sources/Networking/NetworkRequestPerformer.swift
@@ -24,10 +24,11 @@ public protocol NetworkRequestPerformer: Sendable {
     /// Returns a publisher that can be subscribed to, that performs the given request with the given behaviors.
     /// - Parameters:
     ///   - request: The request to perform.
+    ///   - scheduler: The scheduler to receive the call on. The scheduler passed in must match the `@MainActor` requirement to avoid data races.
     ///   - requestBehaviors: The behaviors to apply to the given request.
     /// - Returns: Returns a publisher that can be subscribed to, that performs the given request with the given behaviors.
-    @available(iOS 13.0, *)
-    @discardableResult func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior]) -> AnyPublisher<NetworkResponse, NetworkError>
+    @MainActor
+    @discardableResult func send(_ request: any NetworkRequest, scheduler: some Scheduler, requestBehaviors: [RequestBehavior]) -> AnyPublisher<NetworkResponse, NetworkError>
     
     /// Performs the given request with the given behaviors returning a `NetworkResponse` with async/await, or throwing an error if unsuccessful.
     ///

--- a/Sources/Networking/NetworkRequestPerformer.swift
+++ b/Sources/Networking/NetworkRequestPerformer.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 /// A protocol that defines functions needed to perform requests.
-public protocol NetworkRequestPerformer {
+public protocol NetworkRequestPerformer: Sendable {
     
     /// Performs the given request with the given behaviors.
     ///
@@ -19,7 +19,7 @@ public protocol NetworkRequestPerformer {
     ///   - requestBehaviors: The behaviors to apply to the given request.
     ///   - completion: A completion closure that is called when the request has been completed.
     /// - Returns: The `NetworkSessionDataTask` used to send the request. The implementation must call `resume()` on the task before returning.
-    @discardableResult func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior], completion: ((Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask
+    @discardableResult func send(_ request: any NetworkRequest, requestBehaviors: [RequestBehavior], completion: (@Sendable (Result<NetworkResponse, NetworkError>) -> Void)?) -> NetworkSessionDataTask
 
     /// Returns a publisher that can be subscribed to, that performs the given request with the given behaviors.
     /// - Parameters:

--- a/Sources/Networking/NetworkResponse.swift
+++ b/Sources/Networking/NetworkResponse.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A defined structure for a successful network response.
-public struct NetworkResponse {
+public struct NetworkResponse: Sendable {
     
     /// The data contained in the response.
     public let data: Data?

--- a/Sources/Networking/NetworkSession.swift
+++ b/Sources/Networking/NetworkSession.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 /// Describes an object that coordinates a group of related, network data transfer tasks. This protocol has a similar API to `URLSession` for the purpose of mocking.
-public protocol NetworkSession {
+public protocol NetworkSession: Sendable {
 
     /// Creates a task that retrieves the contents of a URL based on the specified URL request object, and calls a handler upon completion.
     /// - Parameters:

--- a/Sources/Networking/NetworkSessionDataTask.swift
+++ b/Sources/Networking/NetworkSessionDataTask.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Describes a network session task that can be performed. This protocol has a similar API to `URLSessionDataTask` for the purpose of mocking.
-public protocol NetworkSessionDataTask {
+public protocol NetworkSessionDataTask: Sendable {
     
     /// Progress object which represents the task progress. It can be used for task progress tracking.
     ///

--- a/Sources/Networking/RequestBehavior.swift
+++ b/Sources/Networking/RequestBehavior.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A protocol that can be used to implement behavior for requests being made.
-public protocol RequestBehavior {
+public protocol RequestBehavior: Sendable {
     
     /// A function that is called before a request is sent. You may modify the request at this time.
     ///

--- a/Sources/Networking/RequestBehavior.swift
+++ b/Sources/Networking/RequestBehavior.swift
@@ -22,11 +22,6 @@ public protocol RequestBehavior: Sendable {
     func requestDidFinish(result: Result<NetworkResponse, NetworkError>)
 }
 
-public extension RequestBehavior {
-    func requestWillSend(request: inout URLRequest) { }
-    func requestDidFinish(result: Result<NetworkResponse, NetworkError>) { }
-}
-
 extension Array: RequestBehavior where Element == RequestBehavior {
     public func requestWillSend(request: inout URLRequest) {
         forEach { $0.requestWillSend(request: &request) }

--- a/Tests/MockNetworkSession.swift
+++ b/Tests/MockNetworkSession.swift
@@ -10,7 +10,7 @@ import Foundation
 import Networking
 
 /// A mocked version of `NetworkSession` to be used in tests. Allows specification of success or failure cases.
-class MockNetworkSession: NetworkSession {
+final class MockNetworkSession: NetworkSession {
     private let result: Result<Data, Error>
 
     /// Creates a new `MockNetworkSession`.
@@ -41,10 +41,13 @@ class MockNetworkSession: NetworkSession {
     }
 }
 
-private class MockNetworkSessionDataTask: NetworkSessionDataTask {
-    private let resumeClosure: () -> Void
-
-    init(closure: @escaping () -> Void) {
+private final class MockNetworkSessionDataTask: NetworkSessionDataTask {
+    
+    let progress = Progress()
+    
+    private let resumeClosure: @Sendable () -> Void
+    
+    init(closure: @escaping @Sendable () -> Void) {
         self.resumeClosure = closure
     }
 


### PR DESCRIPTION
## What it Does
- Updates Networking to have strict concurrency turned on as well as Swift 6
- Goes through and conforms various types to `Sendable`

## How I Tested
- Built the app, ran the test repeatedly 100 times to make sure they pass
- Tried using this update in Provider

## Notes
- There is an issue where if you call one of the combine based network calls from the main thread and then do things on any other thread as part of the returned combine chain, the app will crash without a compiler warning. Used `@MainActor` to enforce it being called from the thread and then always receiving on that thread. I can't scope it to something like the MainQueueScheduler we have in ViewStore, so I updated the docs to call it out.

